### PR TITLE
Copy the old cliName to a new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ What values you can have under bin:
 | baseURL      | Github endpoint | https://my.github.enterprise.com | github.com |
 | download     | Downloaded package, if not it will just be reported | true | true |
 | nonGithubURL | A non github http server containing tar.gz or .zip fle. If used will ignore any github related config | https://get.helm.sh/helm-v3.4.2-linux-amd64.tar.gz | "" |
+| backup       | If true, it will create a copy of the old cli with todays date, example: tkn_2021_01_10 | true | false |
 
 ### Example config
 
@@ -75,6 +76,7 @@ bins:
     owner: tektoncd
     repo: cli
     match: Linux_x86_64
+    backup: true
   - cli: tkn.exe
     owner: tektoncd
     repo: cli

--- a/data.yaml
+++ b/data.yaml
@@ -9,7 +9,6 @@ bins:
     owner: tektoncd
     repo: cli
     match: Linux_x86_64
-    #match: createaError
     baseURL: github.com
     download: true
   - cli: tkn.exe
@@ -17,7 +16,7 @@ bins:
     repo: cli
     match: Windows_x86_64
     baseURL: github.com
-    download: true
+    backup: true
   - cli: fluxctl
     owner: fluxcd
     repo: flux

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,7 @@ type Bin struct {
 	BaseURL      string `yaml:"baseURL"`
 	Download     bool   `yaml:"download"`
 	NonGithubURL string `yaml:"nonGithubURL"`
+	Backup       bool   `yaml:"backup"`
 }
 
 // Items config file struct


### PR DESCRIPTION
If a file exist with this name it will be copied to a new one.
Else it will just continue.
Then the new download will overwrite the existing one.
* Add backup to the yaml, no value=false and no backup
* Update README