### PR TITLE
use baseURL & uploadURL for github enterprise URI

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -3,6 +3,8 @@
 httpTimeout: 5
 httpInsecure: false
 saveLocation: /tmp/tkn-210102
+# baseURL: https://api.mycomp.com/
+# uploadURL: https://github.mycomp.com/api/v3/upload 
 # maxFileSize: 104857600
 #notOkCompletionArgs:
 #  - sudo
@@ -13,7 +15,6 @@ bins:
     owner: tektoncd
     repo: cli
     match: Linux_x86_64
-    baseURL: https://api.github.com/
     download: true
     completionLocation: /tmp/tkn-completion.sh
     completionArgs:

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -38,8 +38,22 @@ const exeExtension = ".exe"
 func App(ctx context.Context, httpClient *http.Client, configItem *config.Items) error {
 	log := logr.FromContext(ctx)
 
-	// TODO find a way to use configItem.Bins[0].BaseURL to download files from custom github endpoints
-	client := github.NewClient(nil)
+	client := github.NewClient(httpClient)
+
+	// since client is a pointer I can't have a baseURL for each endpoint without allot of logic
+	if configItem.BaseURL != "" && configItem.UploadURL != "" {
+		baseURL, err := url.Parse(configItem.BaseURL)
+		if err != nil {
+			return err
+		}
+		client.BaseURL = baseURL
+
+		uploadURL, err := url.Parse(configItem.UploadURL)
+		if err != nil {
+			return err
+		}
+		client.UploadURL = uploadURL
+	}
 
 	gitHubAPIkey := viper.GetString(config.DefaultGITHUBAPIKEYKey)
 	log.Info(gitHubAPIkey)
@@ -129,16 +143,6 @@ func downloadBin(ctx context.Context, wg *sync.WaitGroup, channel chan error, cl
 
 	var resp *github.RepositoryRelease
 	var er error
-
-	// check if BaseURL is empty, if not it will use that when talking to the github api
-	if binConfig.BaseURL != "" {
-		githubURL, err := url.Parse(binConfig.BaseURL)
-		if err != nil {
-			channel <- er
-			return
-		}
-		client.BaseURL = githubURL
-	}
 
 	// If tag is empty use GetReleaseByTag
 	if binConfig.Tag != "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,7 +22,6 @@ type Bin struct {
 	Repo               string   `yaml:"repo"`
 	Tag                string   `yaml:"tag"`
 	Match              string   `yaml:"match"`
-	BaseURL            string   `yaml:"baseURL"`
 	Download           bool     `yaml:"download"`
 	NonGithubURL       string   `yaml:"nonGithubURL"`
 	Backup             bool     `yaml:"backup"`
@@ -37,6 +36,8 @@ type Items struct {
 	HTTPtimeout         int      `yaml:"httpTimeout"`
 	HTTPinsecure        bool     `yaml:"httpInsecure"`
 	SaveLocation        string   `yaml:"saveLocation"`
+	BaseURL             string   `yaml:"baseURL"`
+	UploadURL           string   `yaml:"uploadURL"`
 	MaxFileSize         int64    `yaml:"maxFileSize"`
 	NotOkCompletionArgs []string `yaml:"notOkCompletionArgs"`
 }
@@ -57,6 +58,9 @@ const (
 
 	DefaultSaveLocationKey = "saveLocation"
 	// defaultSaveLocationValue is defined in ManageConfig()
+
+	DefaultBaseURLKey  = "baseURL"
+	DefaultUploadRLKey = "uploadURL"
 
 	DefaultMaxFileSizeKey   = "maxFileSize"
 	defaultMaxFileSizeValue = int64(104857600) //1024*1024*100 aka 100 Mb
@@ -92,6 +96,9 @@ func ManageConfig(ctx context.Context) (Items, error) {
 	viper.SetDefault(DefaultSaveLocationKey, defaultSaveLocationValue)
 	viper.SetDefault(DefaultMaxFileSizeKey, defaultMaxFileSizeValue)
 	viper.SetDefault(DefaultNotOkCompletionArgsKey, defaultNotOkCompletionArgsValue)
+	viper.SetDefault(DefaultBaseURLKey, "")
+	viper.SetDefault(DefaultUploadRLKey, "")
+	viper.SetDefault(DefaultHTTPinsecureKey, defaultHTTPinsecureValue)
 
 	// Run initial to look if env FILE exists to manage the config
 	viper.AutomaticEnv()


### PR DESCRIPTION
Unable to use the endpoint per bin download, due to it's a pointer.
Would requiere lots of logic to manage it.
The users will have to run the script one for github.com and one for
enterprise. Would need a real endpoint to be able to perfrom real tests.